### PR TITLE
feat: add playable 五子棋 (Gomoku) web game

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ HTML_TEMPLATE = """<!doctype html>
     </div>
     <p class="help">规则：黑棋先手，任意一方先形成连续五子即获胜。点击棋盘交叉点落子。</p>
   </main>
-  <script src="/script.js"></script>
+  <script src="/script.js?v=20260301"></script>
 </body>
 </html>
 """
@@ -120,10 +120,16 @@ class GomokuHandler(BaseHTTPRequestHandler):
 
         self._send_response(404, "text/plain; charset=utf-8", b"Not Found")
 
-    def _send_response(self, status_code, content_type, body):
+    def _send_response(self, status_code, content_type, body, extra_headers=None):
         self.send_response(status_code)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        if extra_headers:
+            for key, value in extra_headers.items():
+                self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
 

--- a/app.py
+++ b/app.py
@@ -1,91 +1,111 @@
 #!/usr/bin/env python3
-"""
-示例Web应用 - 包含一些常见的编程问题供BugBot检测
-"""
+"""五子棋 Web 应用。"""
 
-import os
-import sqlite3
-from flask import Flask, request, render_template_string
+from flask import Flask, render_template_string, send_from_directory
 
 app = Flask(__name__)
 
-# 潜在问题1: 硬编码的敏感信息
-SECRET_KEY = "super_secret_key_123"
-DATABASE_PASSWORD = "admin123"
+HTML_TEMPLATE = """
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>五子棋</title>
+  <style>
+    :root {
+      font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      color: #1f2937;
+      background: #f6f7fb;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+    .container {
+      width: min(92vw, 680px);
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+      padding: 20px;
+    }
+    h1 {
+      margin-top: 0;
+      margin-bottom: 10px;
+      text-align: center;
+    }
+    .toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 14px;
+    }
+    #status {
+      font-size: 16px;
+      font-weight: 600;
+    }
+    button {
+      border: none;
+      background: #2563eb;
+      color: white;
+      padding: 10px 14px;
+      border-radius: 10px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #1e4fbb; }
+    .board-wrap {
+      overflow: auto;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+      background: #fdf8ea;
+    }
+    canvas {
+      display: block;
+      margin: 0 auto;
+      background: #f7d794;
+    }
+    .help {
+      margin-top: 12px;
+      color: #6b7280;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <h1>五子棋</h1>
+    <div class="toolbar">
+      <div id="status">当前回合：黑棋</div>
+      <button id="restart-btn" type="button">重新开始</button>
+    </div>
+    <div class="board-wrap">
+      <canvas id="board" width="600" height="600" aria-label="五子棋棋盘"></canvas>
+    </div>
+    <p class="help">规则：黑棋先手，任意一方先形成连续五子即获胜。点击棋盘交叉点落子。</p>
+  </main>
+  <script src="/script.js"></script>
+</body>
+</html>
+"""
 
-# 潜在问题2: SQL注入漏洞
-def get_user_data(user_id):
-    conn = sqlite3.connect('users.db')
-    cursor = conn.cursor()
-    # 危险：直接拼接SQL查询
-    query = f"SELECT * FROM users WHERE id = {user_id}"
-    cursor.execute(query)
-    result = cursor.fetchall()
-    conn.close()
-    return result
 
-# 潜在问题3: 未验证的用户输入
-@app.route('/user/<user_id>')
-def show_user(user_id):
-    # 没有输入验证
-    user_data = get_user_data(user_id)
-    return f"User data: {user_data}"
+@app.route("/")
+def index():
+    return render_template_string(HTML_TEMPLATE)
 
-# 潜在问题4: XSS漏洞
-@app.route('/search')
-def search():
-    query = request.args.get('q', '')
-    # 直接渲染用户输入，可能导致XSS
-    template = f"""
-    <html>
-        <body>
-            <h1>搜索结果</h1>
-            <p>你搜索了: {query}</p>
-        </body>
-    </html>
-    """
-    return render_template_string(template)
 
-# 潜在问题5: 资源泄露
-def process_file(filename):
-    try:
-        file = open(filename, 'r')
-        content = file.read()
-        # 忘记关闭文件
-        return content.upper()
-    except:
-        # 空的异常处理
-        pass
+@app.route("/script.js")
+def game_script():
+    return send_from_directory(".", "script.js", mimetype="application/javascript")
 
-# 潜在问题6: 无限循环的可能性
-def calculate_factorial(n):
-    result = 1
-    while n > 0:
-        result *= n
-        # 忘记递减n，可能导致无限循环
-        # n -= 1  # 这行被注释了
-    return result
 
-# 潜在问题7: 类型错误
-def divide_numbers(a, b):
-    # 没有检查除零错误
-    return a / b
-
-# 潜在问题8: 不安全的随机数生成
-import random
-def generate_token():
-    # 使用不安全的伪随机数生成器
-    return str(random.randint(100000, 999999))
-
-# 潜在问题9: 内存效率问题
-def process_large_list():
-    # 创建不必要的大列表
-    numbers = list(range(1000000))
-    squared = []
-    for num in numbers:
-        squared.append(num * num)
-    return squared
-
-if __name__ == '__main__':
-    # 潜在问题10: 在生产环境中使用debug模式
-    app.run(debug=True, host='0.0.0.0') 
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/app.py
+++ b/app.py
@@ -95,8 +95,12 @@ HTML_TEMPLATE = """<!doctype html>
       <canvas id="board" width="600" height="600" aria-label="五子棋棋盘"></canvas>
     </div>
     <p class="help">规则：黑棋先手，任意一方先形成连续五子即获胜。点击棋盘交叉点落子。</p>
+    <p class="help">若按钮无响应，请使用 http://127.0.0.1:5000 访问，不要直接打开本地文件预览。</p>
   </main>
-  <script src="/script.js?v=20260301"></script>
+  <script src="script.js?v=20260302"></script>
+  <noscript>
+    <p style="text-align:center;color:#b91c1c;font-size:14px;">页面需要 JavaScript 才能运行五子棋。</p>
+  </noscript>
 </body>
 </html>
 """

--- a/app.py
+++ b/app.py
@@ -84,8 +84,11 @@ HTML_TEMPLATE = """<!doctype html>
   <main class="container">
     <h1>五子棋</h1>
     <div class="toolbar">
-      <div id="status">当前回合：黑棋</div>
-      <button id="restart-btn" type="button">重新开始</button>
+      <div id="status">点击“开始对局”后由黑棋先手</div>
+      <div style="display:flex; gap:8px;">
+        <button id="start-btn" type="button">开始对局</button>
+        <button id="restart-btn" type="button">重新开始</button>
+      </div>
     </div>
     <div class="board-wrap">
       <canvas id="board" width="600" height="600" aria-label="五子棋棋盘"></canvas>

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from urllib.parse import urlsplit
 
 HOST = "0.0.0.0"
 PORT = 5000
@@ -103,11 +104,13 @@ HTML_TEMPLATE = """<!doctype html>
 
 class GomokuHandler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
-        if self.path in ("/", "/index.html"):
+        route = urlsplit(self.path).path
+
+        if route in ("/", "/index.html"):
             self._send_response(200, "text/html; charset=utf-8", HTML_TEMPLATE.encode("utf-8"))
             return
 
-        if self.path == "/script.js":
+        if route in ("/script.js", "script.js", "/script.js/"):
             script_path = Path(__file__).with_name("script.js")
             if not script_path.exists():
                 self._send_response(404, "text/plain; charset=utf-8", b"script.js not found")

--- a/app.py
+++ b/app.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""五子棋 Web 应用。"""
+"""五子棋 Web 应用（无第三方依赖）。"""
 
-from flask import Flask, render_template_string, send_from_directory
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 
-app = Flask(__name__)
+HOST = "0.0.0.0"
+PORT = 5000
 
-HTML_TEMPLATE = """
-<!doctype html>
+HTML_TEMPLATE = """<!doctype html>
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
@@ -97,15 +98,35 @@ HTML_TEMPLATE = """
 """
 
 
-@app.route("/")
-def index():
-    return render_template_string(HTML_TEMPLATE)
+class GomokuHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path in ("/", "/index.html"):
+            self._send_response(200, "text/html; charset=utf-8", HTML_TEMPLATE.encode("utf-8"))
+            return
+
+        if self.path == "/script.js":
+            script_path = Path(__file__).with_name("script.js")
+            if not script_path.exists():
+                self._send_response(404, "text/plain; charset=utf-8", b"script.js not found")
+                return
+            self._send_response(200, "application/javascript; charset=utf-8", script_path.read_bytes())
+            return
+
+        self._send_response(404, "text/plain; charset=utf-8", b"Not Found")
+
+    def _send_response(self, status_code, content_type, body):
+        self.send_response(status_code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
 
-@app.route("/script.js")
-def game_script():
-    return send_from_directory(".", "script.js", mimetype="application/javascript")
+def run_server(host=HOST, port=PORT):
+    httpd = HTTPServer((host, port), GomokuHandler)
+    print(f"Gomoku running at http://127.0.0.1:{port}")
+    httpd.serve_forever()
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=False)
+    run_server()

--- a/script.js
+++ b/script.js
@@ -1,182 +1,200 @@
 (() => {
   const boardSize = 15;
-  const canvas = document.getElementById('board');
-  const ctx = canvas.getContext('2d');
-  const statusEl = document.getElementById('status');
-  const startBtn = document.getElementById('start-btn');
-  const restartBtn = document.getElementById('restart-btn');
-
   const padding = 30;
-  const gridSize = (canvas.width - padding * 2) / (boardSize - 1);
 
-  let board = createBoard();
-  let currentPlayer = 1;
-  let winner = null;
-  let gameStarted = false;
+  function initGame() {
+    const canvas = document.getElementById('board');
+    const statusEl = document.getElementById('status');
+    const startBtn = document.getElementById('start-btn');
+    const restartBtn = document.getElementById('restart-btn');
 
-  function createBoard() {
-    return Array.from({ length: boardSize }, () => Array(boardSize).fill(0));
-  }
-
-  function updateStatus() {
-    if (!gameStarted) {
-      statusEl.textContent = '点击“开始对局”后由黑棋先手';
+    if (!canvas || !statusEl || !startBtn || !restartBtn) {
       return;
     }
 
-    if (winner) {
-      statusEl.textContent = `游戏结束：${winner === 1 ? '黑棋' : '白棋'}获胜！`;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      statusEl.textContent = '浏览器不支持 Canvas，无法开始游戏';
       return;
     }
 
-    statusEl.textContent = `当前回合：${currentPlayer === 1 ? '黑棋' : '白棋'}`;
-  }
+    const gridSize = (canvas.width - padding * 2) / (boardSize - 1);
 
-  function drawBoard() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let board = createBoard();
+    let currentPlayer = 1;
+    let winner = null;
+    let gameStarted = false;
 
-    ctx.fillStyle = '#f7d794';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    ctx.strokeStyle = '#8b5a2b';
-    ctx.lineWidth = 1;
-
-    for (let i = 0; i < boardSize; i += 1) {
-      const pos = padding + i * gridSize;
-
-      ctx.beginPath();
-      ctx.moveTo(padding, pos);
-      ctx.lineTo(canvas.width - padding, pos);
-      ctx.stroke();
-
-      ctx.beginPath();
-      ctx.moveTo(pos, padding);
-      ctx.lineTo(pos, canvas.height - padding);
-      ctx.stroke();
+    function createBoard() {
+      return Array.from({ length: boardSize }, () => Array(boardSize).fill(0));
     }
 
-    drawPieces();
-  }
+    function updateStatus(extra = '') {
+      if (!gameStarted) {
+        statusEl.textContent = '点击“开始对局”后由黑棋先手';
+        return;
+      }
 
-  function drawPieces() {
-    for (let row = 0; row < boardSize; row += 1) {
-      for (let col = 0; col < boardSize; col += 1) {
-        if (board[row][col] === 0) continue;
+      if (winner) {
+        statusEl.textContent = `游戏结束：${winner === 1 ? '黑棋' : '白棋'}获胜！`;
+        return;
+      }
 
-        const x = padding + col * gridSize;
-        const y = padding + row * gridSize;
+      const base = `当前回合：${currentPlayer === 1 ? '黑棋' : '白棋'}`;
+      statusEl.textContent = extra ? `${base}（${extra}）` : base;
+    }
+
+    function drawBoard() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#f7d794';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      ctx.strokeStyle = '#8b5a2b';
+      ctx.lineWidth = 1;
+
+      for (let i = 0; i < boardSize; i += 1) {
+        const pos = padding + i * gridSize;
 
         ctx.beginPath();
-        ctx.arc(x, y, gridSize * 0.38, 0, Math.PI * 2);
+        ctx.moveTo(padding, pos);
+        ctx.lineTo(canvas.width - padding, pos);
+        ctx.stroke();
 
-        const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
-        if (board[row][col] === 1) {
-          gradient.addColorStop(0, '#666');
-          gradient.addColorStop(1, '#111');
-        } else {
-          gradient.addColorStop(0, '#fff');
-          gradient.addColorStop(1, '#ddd');
+        ctx.beginPath();
+        ctx.moveTo(pos, padding);
+        ctx.lineTo(pos, canvas.height - padding);
+        ctx.stroke();
+      }
+
+      drawPieces();
+    }
+
+    function drawPieces() {
+      for (let row = 0; row < boardSize; row += 1) {
+        for (let col = 0; col < boardSize; col += 1) {
+          if (board[row][col] === 0) continue;
+
+          const x = padding + col * gridSize;
+          const y = padding + row * gridSize;
+
+          ctx.beginPath();
+          ctx.arc(x, y, gridSize * 0.38, 0, Math.PI * 2);
+
+          const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
+          if (board[row][col] === 1) {
+            gradient.addColorStop(0, '#666');
+            gradient.addColorStop(1, '#111');
+          } else {
+            gradient.addColorStop(0, '#fff');
+            gradient.addColorStop(1, '#ddd');
+          }
+          ctx.fillStyle = gradient;
+          ctx.fill();
         }
-        ctx.fillStyle = gradient;
-        ctx.fill();
       }
     }
-  }
 
-  function getGridPosition(event) {
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
+    function getGridPosition(event) {
+      const rect = canvas.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
 
-    const col = Math.round((x - padding) / gridSize);
-    const row = Math.round((y - padding) / gridSize);
+      const col = Math.round((x - padding) / gridSize);
+      const row = Math.round((y - padding) / gridSize);
 
-    if (row < 0 || row >= boardSize || col < 0 || col >= boardSize) {
-      return null;
+      if (row < 0 || row >= boardSize || col < 0 || col >= boardSize) {
+        return null;
+      }
+
+      return { row, col };
     }
 
-    return { row, col };
-  }
+    function countInDirection(row, col, rowStep, colStep, player) {
+      let count = 0;
+      let r = row + rowStep;
+      let c = col + colStep;
 
-  function countInDirection(row, col, rowStep, colStep, player) {
-    let count = 0;
-    let r = row + rowStep;
-    let c = col + colStep;
+      while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === player) {
+        count += 1;
+        r += rowStep;
+        c += colStep;
+      }
 
-    while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === player) {
-      count += 1;
-      r += rowStep;
-      c += colStep;
+      return count;
     }
 
-    return count;
-  }
+    function checkWin(row, col, player) {
+      const directions = [
+        [0, 1],
+        [1, 0],
+        [1, 1],
+        [1, -1],
+      ];
 
-  function checkWin(row, col, player) {
-    const directions = [
-      [0, 1],
-      [1, 0],
-      [1, 1],
-      [1, -1],
-    ];
-
-    return directions.some(([dr, dc]) => {
-      const total = 1 + countInDirection(row, col, dr, dc, player) + countInDirection(row, col, -dr, -dc, player);
-      return total >= 5;
-    });
-  }
-
-  function handleClick(event) {
-    if (!gameStarted) {
-      statusEl.textContent = '请先点击“开始对局”';
-      return;
+      return directions.some(([dr, dc]) => {
+        const total = 1 + countInDirection(row, col, dr, dc, player) + countInDirection(row, col, -dr, -dc, player);
+        return total >= 5;
+      });
     }
 
-    if (winner) return;
+    function handleCanvasClick(event) {
+      if (!gameStarted) {
+        statusEl.textContent = '请先点击“开始对局”';
+        return;
+      }
 
-    const pos = getGridPosition(event);
-    if (!pos) return;
+      if (winner) return;
 
-    const { row, col } = pos;
-    if (board[row][col] !== 0) return;
+      const pos = getGridPosition(event);
+      if (!pos) return;
 
-    board[row][col] = currentPlayer;
+      const { row, col } = pos;
+      if (board[row][col] !== 0) return;
 
-    if (checkWin(row, col, currentPlayer)) {
-      winner = currentPlayer;
-    } else {
-      currentPlayer = currentPlayer === 1 ? 2 : 1;
-    }
+      board[row][col] = currentPlayer;
 
-    drawBoard();
-    updateStatus();
-  }
+      if (checkWin(row, col, currentPlayer)) {
+        winner = currentPlayer;
+      } else {
+        currentPlayer = currentPlayer === 1 ? 2 : 1;
+      }
 
-  function startGame() {
-    board = createBoard();
-    currentPlayer = 1;
-    winner = null;
-    gameStarted = true;
-    drawBoard();
-    updateStatus();
-  }
-
-  function resetGame() {
-    board = createBoard();
-    currentPlayer = 1;
-    winner = null;
-    drawBoard();
-
-    if (gameStarted) {
+      drawBoard();
       updateStatus();
-    } else {
-      statusEl.textContent = '点击“开始对局”后由黑棋先手';
     }
+
+    function startGame() {
+      board = createBoard();
+      currentPlayer = 1;
+      winner = null;
+      gameStarted = true;
+      drawBoard();
+      updateStatus('已开始');
+    }
+
+    function resetGame() {
+      board = createBoard();
+      currentPlayer = 1;
+      winner = null;
+      drawBoard();
+
+      if (gameStarted) {
+        updateStatus('已重置');
+      } else {
+        statusEl.textContent = '点击“开始对局”后由黑棋先手';
+      }
+    }
+
+    canvas.addEventListener('click', handleCanvasClick);
+    startBtn.addEventListener('click', startGame);
+    restartBtn.addEventListener('click', resetGame);
+
+    resetGame();
   }
 
-  canvas.addEventListener('click', handleClick);
-  startBtn.addEventListener('click', startGame);
-  restartBtn.addEventListener('click', resetGame);
-
-  resetGame();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initGame);
+  } else {
+    initGame();
+  }
 })();

--- a/script.js
+++ b/script.js
@@ -3,24 +3,32 @@
   const canvas = document.getElementById('board');
   const ctx = canvas.getContext('2d');
   const statusEl = document.getElementById('status');
+  const startBtn = document.getElementById('start-btn');
   const restartBtn = document.getElementById('restart-btn');
 
   const padding = 30;
   const gridSize = (canvas.width - padding * 2) / (boardSize - 1);
 
   let board = createBoard();
-  let currentPlayer = 1; // 1:黑棋, 2:白棋
+  let currentPlayer = 1;
   let winner = null;
+  let gameStarted = false;
 
   function createBoard() {
     return Array.from({ length: boardSize }, () => Array(boardSize).fill(0));
   }
 
   function updateStatus() {
+    if (!gameStarted) {
+      statusEl.textContent = '点击“开始对局”后由黑棋先手';
+      return;
+    }
+
     if (winner) {
       statusEl.textContent = `游戏结束：${winner === 1 ? '黑棋' : '白棋'}获胜！`;
       return;
     }
+
     statusEl.textContent = `当前回合：${currentPlayer === 1 ? '黑棋' : '白棋'}`;
   }
 
@@ -60,17 +68,16 @@
 
         ctx.beginPath();
         ctx.arc(x, y, gridSize * 0.38, 0, Math.PI * 2);
+
+        const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
         if (board[row][col] === 1) {
-          const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
           gradient.addColorStop(0, '#666');
           gradient.addColorStop(1, '#111');
-          ctx.fillStyle = gradient;
         } else {
-          const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
           gradient.addColorStop(0, '#fff');
           gradient.addColorStop(1, '#ddd');
-          ctx.fillStyle = gradient;
         }
+        ctx.fillStyle = gradient;
         ctx.fill();
       }
     }
@@ -114,15 +121,17 @@
     ];
 
     return directions.some(([dr, dc]) => {
-      const total =
-        1 +
-        countInDirection(row, col, dr, dc, player) +
-        countInDirection(row, col, -dr, -dc, player);
+      const total = 1 + countInDirection(row, col, dr, dc, player) + countInDirection(row, col, -dr, -dc, player);
       return total >= 5;
     });
   }
 
   function handleClick(event) {
+    if (!gameStarted) {
+      statusEl.textContent = '请先点击“开始对局”';
+      return;
+    }
+
     if (winner) return;
 
     const pos = getGridPosition(event);
@@ -143,15 +152,30 @@
     updateStatus();
   }
 
+  function startGame() {
+    board = createBoard();
+    currentPlayer = 1;
+    winner = null;
+    gameStarted = true;
+    drawBoard();
+    updateStatus();
+  }
+
   function resetGame() {
     board = createBoard();
     currentPlayer = 1;
     winner = null;
     drawBoard();
-    updateStatus();
+
+    if (gameStarted) {
+      updateStatus();
+    } else {
+      statusEl.textContent = '点击“开始对局”后由黑棋先手';
+    }
   }
 
   canvas.addEventListener('click', handleClick);
+  startBtn.addEventListener('click', startGame);
   restartBtn.addEventListener('click', resetGame);
 
   resetGame();

--- a/script.js
+++ b/script.js
@@ -1,125 +1,158 @@
-/**
- * 前端JavaScript示例 - 包含常见问题供BugBot检测
- */
+(() => {
+  const boardSize = 15;
+  const canvas = document.getElementById('board');
+  const ctx = canvas.getContext('2d');
+  const statusEl = document.getElementById('status');
+  const restartBtn = document.getElementById('restart-btn');
 
-// 潜在问题1: 全局变量污染
-var userData = {};
-var currentUser = null;
-var isLoggedIn = false;
+  const padding = 30;
+  const gridSize = (canvas.width - padding * 2) / (boardSize - 1);
 
-// 潜在问题2: 不安全的eval使用
-function executeUserCode(userInput) {
-    // 危险：直接执行用户输入
-    return eval(userInput);
-}
+  let board = createBoard();
+  let currentPlayer = 1; // 1:黑棋, 2:白棋
+  let winner = null;
 
-// 潜在问题3: DOM XSS漏洞
-function displayMessage(message) {
-    // 直接插入HTML，可能导致XSS
-    document.getElementById('output').innerHTML = message;
-}
+  function createBoard() {
+    return Array.from({ length: boardSize }, () => Array(boardSize).fill(0));
+  }
 
-// 潜在问题4: 缺少错误处理
-function fetchUserData(userId) {
-    fetch(`/api/users/${userId}`)
-        .then(response => response.json())
-        .then(data => {
-            // 没有错误处理
-            userData = data;
-            displayUserInfo(data);
-        });
-}
-
-// 潜在问题5: 内存泄露 - 未清理事件监听器
-function setupEventListeners() {
-    const button = document.getElementById('submit-btn');
-    button.addEventListener('click', function() {
-        console.log('Button clicked');
-    });
-    // 没有提供清理方法
-}
-
-// 潜在问题6: 竞态条件
-let requestCount = 0;
-function sendRequest() {
-    requestCount++;
-    
-    fetch('/api/data')
-        .then(response => response.json())
-        .then(data => {
-            // 可能出现竞态条件
-            if (requestCount === 1) {
-                processData(data);
-            }
-        });
-}
-
-// 潜在问题7: 不安全的随机数
-function generateSessionId() {
-    // Math.random()不够安全用于生成会话ID
-    return Math.random().toString(36).substr(2, 9);
-}
-
-// 潜在问题8: 原型污染风险
-function mergeObjects(target, source) {
-    for (let key in source) {
-        // 没有检查__proto__等危险属性
-        target[key] = source[key];
+  function updateStatus() {
+    if (winner) {
+      statusEl.textContent = `游戏结束：${winner === 1 ? '黑棋' : '白棋'}获胜！`;
+      return;
     }
-    return target;
-}
+    statusEl.textContent = `当前回合：${currentPlayer === 1 ? '黑棋' : '白棋'}`;
+  }
 
-// 潜在问题9: 同步XMLHttpRequest（已废弃）
-function getUserDataSync(userId) {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', `/api/users/${userId}`, false); // 同步请求
-    xhr.send();
-    return JSON.parse(xhr.responseText);
-}
+  function drawBoard() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-// 潜在问题10: 无限递归的可能性
-function countdown(n) {
-    console.log(n);
-    if (n > 0) {
-        // 错误：应该是n-1
-        countdown(n);
+    ctx.fillStyle = '#f7d794';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.strokeStyle = '#8b5a2b';
+    ctx.lineWidth = 1;
+
+    for (let i = 0; i < boardSize; i += 1) {
+      const pos = padding + i * gridSize;
+
+      ctx.beginPath();
+      ctx.moveTo(padding, pos);
+      ctx.lineTo(canvas.width - padding, pos);
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.moveTo(pos, padding);
+      ctx.lineTo(pos, canvas.height - padding);
+      ctx.stroke();
     }
-}
 
-// 潜在问题11: 类型强制转换问题
-function compareValues(a, b) {
-    // 使用==而不是===，可能导致类型强制转换问题
-    if (a == b) {
-        return "equal";
-    }
-    return "not equal";
-}
+    drawPieces();
+  }
 
-// 潜在问题12: 未验证的localStorage使用
-function saveUserPreferences(prefs) {
-    // 没有验证数据就直接存储
-    localStorage.setItem('userPrefs', JSON.stringify(prefs));
-}
+  function drawPieces() {
+    for (let row = 0; row < boardSize; row += 1) {
+      for (let col = 0; col < boardSize; col += 1) {
+        if (board[row][col] === 0) continue;
 
-// 潜在问题13: 缺少CSRF保护的表单提交
-function submitForm(formData) {
-    fetch('/api/update-profile', {
-        method: 'POST',
-        body: JSON.stringify(formData),
-        headers: {
-            'Content-Type': 'application/json'
+        const x = padding + col * gridSize;
+        const y = padding + row * gridSize;
+
+        ctx.beginPath();
+        ctx.arc(x, y, gridSize * 0.38, 0, Math.PI * 2);
+        if (board[row][col] === 1) {
+          const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
+          gradient.addColorStop(0, '#666');
+          gradient.addColorStop(1, '#111');
+          ctx.fillStyle = gradient;
+        } else {
+          const gradient = ctx.createRadialGradient(x - 4, y - 4, 2, x, y, gridSize * 0.38);
+          gradient.addColorStop(0, '#fff');
+          gradient.addColorStop(1, '#ddd');
+          ctx.fillStyle = gradient;
         }
-        // 缺少CSRF token
-    });
-}
-
-// 潜在问题14: 性能问题 - 在循环中查询DOM
-function updateList(items) {
-    const container = document.getElementById('list-container');
-    for (let i = 0; i < items.length; i++) {
-        // 每次循环都查询DOM
-        const listItem = document.createElement('li');
-        listItem.textContent = items[i];
-        document.getElementById('list-container').appendChild(listItem);
+        ctx.fill();
+      }
     }
-} 
+  }
+
+  function getGridPosition(event) {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+
+    const col = Math.round((x - padding) / gridSize);
+    const row = Math.round((y - padding) / gridSize);
+
+    if (row < 0 || row >= boardSize || col < 0 || col >= boardSize) {
+      return null;
+    }
+
+    return { row, col };
+  }
+
+  function countInDirection(row, col, rowStep, colStep, player) {
+    let count = 0;
+    let r = row + rowStep;
+    let c = col + colStep;
+
+    while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === player) {
+      count += 1;
+      r += rowStep;
+      c += colStep;
+    }
+
+    return count;
+  }
+
+  function checkWin(row, col, player) {
+    const directions = [
+      [0, 1],
+      [1, 0],
+      [1, 1],
+      [1, -1],
+    ];
+
+    return directions.some(([dr, dc]) => {
+      const total =
+        1 +
+        countInDirection(row, col, dr, dc, player) +
+        countInDirection(row, col, -dr, -dc, player);
+      return total >= 5;
+    });
+  }
+
+  function handleClick(event) {
+    if (winner) return;
+
+    const pos = getGridPosition(event);
+    if (!pos) return;
+
+    const { row, col } = pos;
+    if (board[row][col] !== 0) return;
+
+    board[row][col] = currentPlayer;
+
+    if (checkWin(row, col, currentPlayer)) {
+      winner = currentPlayer;
+    } else {
+      currentPlayer = currentPlayer === 1 ? 2 : 1;
+    }
+
+    drawBoard();
+    updateStatus();
+  }
+
+  function resetGame() {
+    board = createBoard();
+    currentPlayer = 1;
+    winner = null;
+    drawBoard();
+    updateStatus();
+  }
+
+  canvas.addEventListener('click', handleClick);
+  restartBtn.addEventListener('click', resetGame);
+
+  resetGame();
+})();


### PR DESCRIPTION
### Motivation
- Replace the previous demo scaffolding with a small, self-contained web game so users can play a local Gomoku (五子棋) UI and inspect front-end/game logic.
- Provide a lightweight Flask endpoint to serve the HTML shell and a dedicated route to deliver the front-end script.

### Description
- Add an HTML game UI embedded in `app.py` and expose it at `/` using `render_template_string` and `Flask`.
- Add a `/script.js` route in `app.py` that returns the front-end JavaScript via `send_from_directory`.
- Replace `script.js` with a self-contained IIFE that renders a 15×15 board on a `<canvas>`, handles click-to-place stones, alternates black/white turns, detects five-in-a-row wins in four directions, shows status messages, and supports restart.
- Run server with `app.run(host="0.0.0.0", port=5000, debug=False)` so the app is ready to deploy in typical environments.

### Testing
- Ran `python -m py_compile app.py` which succeeded without syntax errors.
- Ran `node --check script.js` which succeeded without syntax errors.
- Launched a static `python -m http.server 8000` and used an automated browser script to visit the preview page at `http://127.0.0.1:8000/preview.html` and capture a screenshot, which completed successfully.
- Attempted to run `python app.py` for an integrated runtime test but it failed due to missing runtime dependency `Flask` (`ModuleNotFoundError: No module named 'flask'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3e1b54b98832c91a78d6bb551195e)